### PR TITLE
Fix inmem backend configuration

### DIFF
--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -117,7 +117,7 @@ backend "mysql" {
 {% endif %}
 
 {% if vault_backend == "inmem" %}
-backend "inmem"
+backend "inmem" {}
 {% endif %}
 
 {% if vault_backend == "file" %}


### PR DESCRIPTION
Vault fails to start when the backend is set as inmem without the empty {}
