### PR TITLE
Ensure libcap2-bin is installed before assigning capabilities

### DIFF
--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -1,2 +1,4 @@
 ---
 # tasks file for vault (Ubuntu specific)
+- name: Install libcap2-bin
+  apt: name=libcap2-bin state=latest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -70,7 +70,7 @@
   tags: vault
 
 - name: Ensure libcap2-bin is installed
-  package: name=libcap2-bin state=installed
+  apt: name=libcap2-bin state=installed
 
 - name: Give vault access to mlock syscall
   capabilities: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,9 +69,6 @@
   notify: restart vault
   tags: vault
 
-- name: Ensure libcap2-bin is installed
-  apt: name=libcap2-bin state=installed
-
 - name: Give vault access to mlock syscall
   capabilities: >
     path={{ vault_install_dir }}/vault

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,6 +69,9 @@
   notify: restart vault
   tags: vault
 
+- name: Ensure libcap2-bin is installed
+  package: name=libcap2-bin state=installed
+
 - name: Give vault access to mlock syscall
   capabilities: >
     path={{ vault_install_dir }}/vault


### PR DESCRIPTION
Otherwise we run in to issues...

16:32:24.189 1446049944,,ui,message,    paravirtual: TASK: [kbrebanov.vault | Give vault access to mlock syscall] ******************
16:32:24.305 1446049944,,ui,message,    paravirtual: failed: [127.0.0.1] => {"failed": true}
16:32:24.305 1446049944,,ui,message,    paravirtual: msg: Failed to find required executable getcap
16:32:24.305 1446049944,,ui,message,    paravirtual:
16:32:24.306 1446049944,,ui,message,    paravirtual: FATAL: all hosts have already failed -- aborting
