### PR TITLE
Fix bug with vault_listener_tcp_tls_disable

### DIFF
--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -10,8 +10,6 @@ listener "tcp" {
   address = "{{ vault_listener_tcp_address }}"
 {% if vault_listener_tcp_tls_disable %}
   tls_disable = 1
-{% else %}
-  tls_disable = 0
 {% endif %}
 {% if vault_listener_tcp_tls_cert_file and not vault_listener_tcp_tls_disable %}
   tls_cert_file = "{{ vault_listener_tcp_tls_cert_file }}"


### PR DESCRIPTION
Setting vault_listener_tcp_tls_disable to False doesn't result in TLS being disabled, as the
template renders "tls_disable = 0", which non-intuitively still disables TLS.

According to the Vault documentation (https://vaultproject.io/docs/config/index.html):
"If non-empty, then TLS will be disabled"

Have also raised Vault issue:
https://github.com/hashicorp/vault/issues/743
