### PR TITLE
Make capabilities task not always report changed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,7 +72,7 @@
 - name: Give vault access to mlock syscall
   capabilities: >
     path={{ vault_install_dir }}/vault
-    capability='cap_ipc_lock=+ep'
+    capability='cap_ipc_lock+ep'
     state=present
 
 - name: Ensure Vault service is started and enabled on boot


### PR DESCRIPTION
I noticed that whenever I ran my playbook to set up Vault that Ansible was always reporting that this particular task had changed something -- e.g.:

```
$ sudo ansible-playbook site.yaml --tags=vault -vv
...
TASK [Give vault access to mlock syscall] **************************************
task path: /var/ACMe/vault_cap.yml:3
changed: [localhost] => {"changed": true, "msg": "capabilities changed", "state": "present", "stdout": "", "stdout_lines": []}
...
PLAY RECAP *********************************************************************
localhost                  : ok=21   changed=1    unreachable=0    failed=0
```

I did some experimenting and it appears that the extra `=` sign is what makes it do this. With this change, I get the following on an already provisioned system:

```
$ sudo ansible-playbook site.yaml --tags=vault -vv
...
TASK [vault : Give vault access to mlock syscall] ******************************
task path: /var/ACMe/roles/vault/tasks/main.yml:47
ok: [localhost] => {"changed": false, "state": "present"}
...
PLAY RECAP *********************************************************************
localhost                  : ok=21   changed=0    unreachable=0    failed=0
```

```
$ getcap /usr/local/bin/vault
/usr/local/bin/vault = cap_ipc_lock+ep
```

It also sets the capability properly on a system where the capability was present. For example, I can do:

```
$ sudo setcap cap_ipc_lock+e /usr/local/bin/vault
$ getcap /usr/local/bin/vault
/usr/local/bin/vault =
$ sudo ansible-playbook site.yaml --tags=vault -vv
...
TASK [vault : Give vault access to mlock syscall] ******************************
task path: /var/ACMe/roles/vault/tasks/main.yml:47
changed: [localhost] => {"changed": true, "msg": "capabilities changed", "state": "present", "stdout": "", "stdout_lines": []}
...
PLAY RECAP *********************************************************************
localhost                  : ok=21   changed=1    unreachable=0    failed=0

$ getcap /usr/local/bin/vault
/usr/local/bin/vault = cap_ipc_lock+ep
```

so it works properly in both cases.
