### PR TITLE
Add copy of TLS listener cert and key files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,7 +49,9 @@ vault_backend_file_path: ''
 vault_listener_tcp_address: "127.0.0.1:8200"
 vault_listener_tcp_tls_disable: true
 vault_listener_tcp_tls_cert_file: ''
+vault_listener_tcp_tls_cert_local_file: ''
 vault_listener_tcp_tls_key_file: ''
+vault_listener_tcp_tls_key_local_file: ''
 vault_listener_tcp_tls_min_version: tls12
 
 vault_telemetry_statsite_address: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,6 +69,28 @@
   notify: restart vault
   tags: vault
 
+- name: Copy Vault TLS certificate
+  copy: >
+    dest="{{ vault_listener_tcp_tls_cert_file }}"
+    src="{{ vault_listener_tcp_tls_cert_local_file }}"
+    owner={{ vault_user }}
+    group={{ vault_group }}
+    mode=0644
+  notify: restart vault
+  when: vault_listener_tcp_tls_cert_file and vault_listener_tcp_tls_cert_local_file
+  tags: vault
+
+- name: Copy Vault TLS key
+  copy: >
+    dest="{{ vault_listener_tcp_tls_key_file }}"
+    src="{{ vault_listener_tcp_tls_key_local_file }}"
+    owner={{ vault_user }}
+    group={{ vault_group }}
+    mode=0600
+  notify: restart vault
+  when: vault_listener_tcp_tls_key_file and vault_listener_tcp_tls_key_local_file
+  tags: vault
+
 - name: Give vault access to mlock syscall
   capabilities: >
     path={{ vault_install_dir }}/vault


### PR DESCRIPTION
Added new properties to make it easier to deploy TLS cert/key and restart Vault (reload doesn't seem to work, at least on CentOS 6 with its ancient Upstart)
