### PR TITLE
Better handling of upstart vs systemd

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,30 +105,21 @@
   tags:
     - vault
 
-- name: Create Vault systemd configuration
   become: yes
   template:
-    src: vault.service.j2
-    dest: /etc/systemd/system/vault.service
     owner: root
     group: root
     mode: 0644
-  when: ansible_distribution_release|lower == 'xenial'
   notify:
-    - reload systemd
     - restart vault
   tags:
     - vault
 
-- name: Create Vault upstart configuration
   become: yes
   template:
-    src: vault.conf.j2
-    dest: /etc/init/vault.conf
     owner: root
     group: root
     mode: 0644
-  when: ansible_distribution_release|lower == 'trusty'
   notify:
     - restart vault
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -105,8 +105,11 @@
   tags:
     - vault
 
+- name: Create Vault upstart configuration
   become: yes
   template:
+    src: vault.conf.j2
+    dest: /etc/init/vault.conf
     owner: root
     group: root
     mode: 0644
@@ -114,9 +117,13 @@
     - restart vault
   tags:
     - vault
+  when: ansible_service_mgr == "upstart"
 
+- name: Create Vault systemd configuration
   become: yes
   template:
+    src: vault.service.j2
+    dest: /lib/systemd/system/vault.service
     owner: root
     group: root
     mode: 0644
@@ -124,6 +131,7 @@
     - restart vault
   tags:
     - vault
+  when: ansible_service_mgr == "systemd"
 
 - name: Create Vault configuration file
   become: yes

--- a/templates/vault.service.j2
+++ b/templates/vault.service.j2
@@ -1,13 +1,16 @@
 [Unit]
 Description=Vault server
-After=network.target
+Requires=network-online.target
+After=network-online.target consul.service
 
 [Service]
-ExecStart={{ vault_install_dir }}/vault server -config {{ vault_config_dir }}/vault.hcl
-StandardOutput=journal
+EnvironmentFile=-/etc/sysconfig/vault
 Restart=on-failure
+PIDFile={{ vault_pid_file }}
+Type=simple
 User={{ vault_user }}
 Group={{ vault_group }}
+ExecStart={{ vault_install_dir }}/vault server -config={{ vault_config_dir }}/vault.hcl > {{ vault_log_file }} 2>&1
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
1. The current implementation "guesses" which version to use against the Ubuntu version, we we can simple use the `ansible_service_mgr` var to know for sure.
2. There is no need to handle restarts of the service differently, Ansible can handle this for us out of the box.
3. I've made some minor changes to the systemd file.